### PR TITLE
update README for post-release v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,9 @@ There are many ways of contributing to the development of Voyant Tools:
 
 Voyant Tools is an open-source project and the code is available through [GitHub](http://github.com/sgsinclair/Voyant). The code is under a [GPL3 license](http://www.gnu.org/licenses/gpl-3.0.en.html) and the content of the web application is under a [Creative Commons By Attribution license](https://creativecommons.org/licenses/by/4.0/).
 
-# Voyant Tools 2.0
-The currently available version of [Voyant Tools](http://voyant-tools.org/) is 1.0 but version 2.0 is in active development and is expected to replace 1.0 in the first half of 2015. Voyant Tools 2.0 is a complete rewrite that is focused on better performance and scalability, as well as improved functionality (such as more powerful search).
 
 ## Releases
+* **UNKNOWN DATE** - 2.2 
 * Dec 3, 2014 - 2.0 M1 (Preview Release): Initial Release
 
 ##  Known Issues


### PR DESCRIPTION
I'm not entirely sure, but from the tags it looks like v2 was released some time ago & we're currently on v. 2.2. This proposed change semi-fixes the README, but I don't have the actual changelog in front of me.